### PR TITLE
Allow Litmus rendering to run with use_cache.

### DIFF
--- a/triggermail_templates.py
+++ b/triggermail_templates.py
@@ -152,7 +152,7 @@ class PreviewTemplate(_BasePreviewCommand):
         use_cache = settings.get('use_cache', DEFAULT_USE_CACHE_SETTING)
         extra_params = dict(unique_user=os.environ['USER'] if use_cache else '')
         if use_cache:
-            extra_params['file_map'] = {}
+            extra_params['file_map'] = json.dumps({})
         return extra_params
 
     def run(self, edit):


### PR DESCRIPTION
Resolves https://github.com/TriggerMail/TriggerMail_templates/issues/472.
